### PR TITLE
Multi folder watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,3 @@ This script will combine an overlay image with a second image, save a copy, and 
 ### Technologies used:
 - watchdog
 - Python Imaging Library (PIL)
-
-**Trash commit line**

--- a/original-folder/.gitignore
+++ b/original-folder/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/print-folder/.gitignore
+++ b/print-folder/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/save-folder/.gitignore
+++ b/save-folder/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/create_file.py
+++ b/tests/create_file.py
@@ -2,6 +2,6 @@ import os, time
 
 
 # test files
-os.system('echo > ../test.txt')
+os.system('echo > ../watch-folder/test.txt')
 time.sleep(5)
-os.system('rm ../test.txt')
+os.system('rm ../watch-folder/test.txt')

--- a/tests/create_file.py
+++ b/tests/create_file.py
@@ -3,5 +3,7 @@ import os, time
 
 # test files
 os.system('echo > ../watch-folder/test.txt')
-time.sleep(5)
+time.sleep(3)
 os.system('rm ../watch-folder/test.txt')
+os.system('rm ../original-folder/test.txt')
+os.system('rm ../save-folder/test.txt')

--- a/watch-folder/.gitignore
+++ b/watch-folder/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/watch.py
+++ b/watch.py
@@ -1,8 +1,19 @@
-import time, sys
+import time, sys, os
 from watchdog.observers import Observer
 from watchdog.events import PatternMatchingEventHandler
 
 currentImage = ''
+originalFolder = 'original-folder/' # Folder to keep a copy of the originals
+watchFolder = 'watch-folder/' # Folder to watch for new images.
+saveFolder = 'save-folder/' # Folder to save images after they have been processed.
+printFolder = 'print-folder/' # Watch folder to print images.
+'''
+# Flow of images follow this
+1. Picture is taken and written to watch-folder/
+2. Copy of original is made in original-folder/ and image is processed and saved in saveFolder/
+3. If user decides to process all pictures, after image is processed, one copy gets written to printFolder/
+    - If user decides to manually select, User decides which pictures to print and manually copies an image to the print-folder/
+'''
 
 # set boolean variable to determine if this will process ALL pictures, or manually select pictures. Variable processAllPictures? = boolean by user input.
 while True:

--- a/watch.py
+++ b/watch.py
@@ -70,10 +70,21 @@ class handleChanges(PatternMatchingEventHandler):
     def on_deleted(self, event):
         self.process(event)
 
+
+# Should these functions be outside of class?
+def processImage(currentImage):
+    """
+    processImage() should take currentImage parameter and overlay the overlayImage above it.
+    The combined picture should be written to save folder
+    """
+    print currentImage + 'this is the current image'
+
+
+
 if __name__ == '__main__':
     args = sys.argv[1:]
     observer = Observer()
-    observer.schedule(handleChanges(), path=args[0] if args else '.')
+    observer.schedule(handleChanges(), path=args[0] if args else './' + watchFolder)
     observer.start()
 
     try:
@@ -84,9 +95,5 @@ if __name__ == '__main__':
 
     observer.join()
 
-# define library requirements
-
-
-# need to declare save and print directories
 # set base image
 # set overlay image

--- a/watch.py
+++ b/watch.py
@@ -70,6 +70,10 @@ class handleChanges(PatternMatchingEventHandler):
 			print 'print folder found'
 
 	def on_created(self, event):
+		"""
+		on_created() handles file creation
+		depending on where file was created (taken from fileInfo[1]), appropriate function will be invoked
+		"""
 		currentImage = event.src_path
 
 		fileInfo = event.src_path.split('/')
@@ -83,6 +87,9 @@ class handleChanges(PatternMatchingEventHandler):
 			print '----------------------------------------'
 
 	def on_deleted(self, event):
+		"""
+		on_deleted() prints name of file deleted from name of directory
+		"""
 		fileInfo = event.src_path.split('/')
 
 		print fileInfo[2] + ' deleted from ' + fileInfo[1]
@@ -92,12 +99,14 @@ def processImage(currentImage):
 	"""
 	processImage() should take currentImage parameter and overlay the overlayImage above it.
 	The combined picture should be written to save folder
+	This function should call processImage.py to create the overlay and pass the image file back in to main watch.py to move it to the appropriate folders.
 	"""
 	print currentImage + ' is the current image and is being processed...'
 
 def printImage(currentImage):
 	"""
 	printImage() should take currentImage parameter and initiate print sequence.
+	Possible to have this function call print.py to batch print all files in print folder to keep it modularized'
 	"""
 	print currentImage + ' is set to be printed...'
 

--- a/watch.py
+++ b/watch.py
@@ -3,97 +3,114 @@ from watchdog.observers import Observer
 from watchdog.events import PatternMatchingEventHandler
 
 currentImage = ''
-originalFolder = 'original-folder/' # Folder to keep a copy of the originals
-watchFolder = 'watch-folder/' # Folder to watch for new images.
-saveFolder = 'save-folder/' # Folder to save images after they have been processed.
-printFolder = 'print-folder/' # Watch folder to print images.
-'''
+originalFolder = 'original-folder' # Folder to keep a copy of the originals
+watchFolder = 'watch-folder' # Folder to watch for new images. --Needs watch
+saveFolder = 'save-folder' # Folder to save images after they have been processed.
+printFolder = 'print-folder' # Watch folder to print images. --Needs watch
+"""
 # Flow of images follow this
 1. Picture is taken and written to watch-folder/
 2. Copy of original is made in original-folder/ and image is processed and saved in saveFolder/
 3. If user decides to process all pictures, after image is processed, one copy gets written to printFolder/
-    - If user decides to manually select, User decides which pictures to print and manually copies an image to the print-folder/
-'''
+	- If user decides to manually select, User decides which pictures to print and manually copies an image to the print-folder/
+"""
 
 # set boolean variable to determine if this will process ALL pictures, or manually select pictures. Variable processAllPictures? = boolean by user input.
 while True:
-    processAllPictures = raw_input('Process all incoming pictures? (Y/N/Quit): ').lower()
+	processAllPictures = raw_input('Process all  pictures? (Y/N/Quit): ').lower()
 
-    if processAllPictures == 'y':
-        print 'All incoming pictures will be processed. Ctrl + C to quit.'
-        processAllPictures = True
-        break
-    elif processAllPictures == 'n':
-        print 'Pictures must be manually selected to be processed. Ctrl + C to quit.'
-        processAllPictures = False
-        break
-    elif processAllPictures == 'quit':
-        raise SystemExit
-        break
-    else:
-        print "Invalid response, please indicate 'y' for yes or 'n' for no"
+	if processAllPictures == 'y':
+		print 'All  pictures will be processed. Ctrl + C to quit.'
+		processAllPictures = True
+		break
+	elif processAllPictures == 'n':
+		print 'Pictures must be manually selected to be processed. Ctrl + C to quit.'
+		processAllPictures = False
+		break
+	elif processAllPictures == 'quit':
+		raise SystemExit
+		break
+	else:
+		print "Invalid response, please indicate 'y' for yes or 'n' for no"
 
 class handleChanges(PatternMatchingEventHandler):
-    patterns = ["*.jpg", "*.txt"] # .jpg and .txt for now. txt will be removed for production.
-    processAllPictures = processAllPictures
-    print 'process all pics', processAllPictures
+	patterns = ["*.jpg", "*.txt"] # .jpg and .txt for now. txt will be removed for production.
+	processAllPictures = processAllPictures
 
-    def process(self, event):
-        """
-        event.event_type
-            'modified' | 'created' | 'moved' | 'deleted'
-        event.is_directory
-            True | False
-        event.src_path
-            path/to/observed/file
-        """
+	def processImage(self, event):
+		"""
+		event.event_type
+			'modified' | 'created' | 'moved' | 'deleted'
+		event.is_directory
+			True | False
+		event.src_path
+			path/to/observed/file
+		"""
 
-        print event.src_path, event.event_type  # print now only for degug
+		fileInfo = event.src_path.split('/') # Create array with directory information and file name.
+		print fileInfo[1]
+		print event.src_path, event.event_type  # print now only for degug
 
-        # Check event type. looking for created event and/or deleted event for now
-        if event.event_type == 'created':
-            print 'hello this was created'
-            currentImage = event.src_path
+		# Check event type. looking for created event and/or deleted event for now
+		if event.event_type == 'created' and fileInfo[1] == watchFolder:
+			currentImage = event.src_path
 
-            os.system('cp ' + currentImage + ' ./' + originalFolder)
-            print 'copied to ' + originalFolder
-            processImage(currentImage)
+			os.system('cp ' + currentImage + ' ./' + saveFolder + '/')
+			os.system('cp ' + currentImage + ' ./' + originalFolder + '/')
 
-        elif event.event_type == 'deleted':
-            print 'oh shit its gone'
+			print 'copied to ' + originalFolder
+			print 'saved to ' + saveFolder
 
+			processImage(currentImage)
 
-    def on_created(self, event):
-        currentImage = event.src_path
-        self.process(event)
+		elif event.event_type == 'deleted':
+			print 'oh shit its gone'
 
-    def on_deleted(self, event):
-        self.process(event)
+		if event.event_type == 'created' and fileInfo[1] == printFolder:
+			print 'print folder found'
 
+	def on_created(self, event):
+		currentImage = event.src_path
+
+		fileInfo = event.src_path.split('/')
+
+		if fileInfo[1] == watchFolder:
+			self.processImage(event)
+		elif fileInfo[1] == printFolder:
+			# self.printFile(event) # Invoke printFile function with current image
+			print '----------------------------------------'
+			print 'file created in print folder!'
+			print '----------------------------------------'
+
+	def on_deleted(self, event):
+		fileInfo = event.src_path.split('/')
+
+		print fileInfo[2] + ' deleted from ' + fileInfo[1]
 
 # Should these functions be outside of class?
 def processImage(currentImage):
-    """
-    processImage() should take currentImage parameter and overlay the overlayImage above it.
-    The combined picture should be written to save folder
-    """
-    print currentImage + 'this is the current image'
+	"""
+	processImage() should take currentImage parameter and overlay the overlayImage above it.
+	The combined picture should be written to save folder
+	"""
+	print currentImage + ' is the current image and is being processed...'
 
-
+def printImage(currentImage):
+	"""
+	printImage() should take currentImage parameter and initiate print sequence.
+	"""
+	print currentImage + ' is set to be printed...'
 
 if __name__ == '__main__':
-    args = sys.argv[1:]
-    observer = Observer()
-    observer.schedule(handleChanges(), path=args[0] if args else './' + watchFolder)
-    observer.start()
+	args = sys.argv[1:]
+	observer = Observer()
+	observer.schedule(handleChanges(), path=args[0] if args else '.', recursive=True)
+	observer.start()
 
-    try:
-        while True:
-            time.sleep(1)
-    except KeyboardInterrupt:
-        observer.stop()
+	try:
+		while True:
+			time.sleep(1)
+	except KeyboardInterrupt:
+		observer.stop()
 
-    observer.join()
-
-# set base image
-# set overlay image
+	observer.join()

--- a/watch.py
+++ b/watch.py
@@ -33,7 +33,6 @@ while True:
     else:
         print "Invalid response, please indicate 'y' for yes or 'n' for no"
 
-
 class handleChanges(PatternMatchingEventHandler):
     patterns = ["*.jpg", "*.txt"] # .jpg and .txt for now. txt will be removed for production.
     processAllPictures = processAllPictures
@@ -54,8 +53,15 @@ class handleChanges(PatternMatchingEventHandler):
         # Check event type. looking for created event and/or deleted event for now
         if event.event_type == 'created':
             print 'hello this was created'
+            currentImage = event.src_path
+
+            os.system('cp ' + currentImage + ' ./' + originalFolder)
+            print 'copied to ' + originalFolder
+            processImage(currentImage)
+
         elif event.event_type == 'deleted':
             print 'oh shit its gone'
+
 
     def on_created(self, event):
         currentImage = event.src_path


### PR DESCRIPTION
Changed structure of the watch feature so it watches the root directory recursively. This method will allow the user to identify the directory in which the change occurred e.g.: "./watch-folder/picture.jpg" or "./print-folder/picture.jpg"

Added gitignore files to subdirectories so the directory names are included in repo, but the files are not.